### PR TITLE
Update from internal source

### DIFF
--- a/cls/_pkg/isc/rest/compileTimeCheck.cls
+++ b/cls/_pkg/isc/rest/compileTimeCheck.cls
@@ -1,0 +1,70 @@
+Class %pkg.isc.rest.compileTimeCheck [ System = 2 ]
+{
+
+/// Invoke this from CodeMode = objectgenerator methods <br />
+/// Returns a consolidated error %Status with all errors for the class if the specified
+/// overrides are not defined for the current class (references the public variable %class) <br />
+/// Example use: <br />
+/// <code>
+/// ClassMethod "%%CheckClassValidity"() [ CodeMode = objectgenerator, Private, Internal, Final ]
+/// {
+/// 	// Require overriding RESOURCENAME and SOURCECLASS parameters
+/// 	Set overrides = $ListBuild("p:SOURCECLASS","p:RESOURCENAME")
+/// 	Return ##class(%pkg.isc.rest.compileTimeCheck).RequireOverrides(overrides)
+/// }
+/// </code>
+/// If <var>prohibitedOrigin</var> is defined, will also validate that the member's origin is not that class.
+ClassMethod RequireOverrides(overrides As %List, prohibitedOrigin As %Dictionary.Classname = "") As %Status
+{
+	Set sc = $$$OK
+	Set className = %class.Name
+	// Overrides not required in abstract subclasses
+	If $$$comClassKeyGet(className,$$$cCLASSabstract) {
+		Quit $$$OK
+	}
+	Set pointer = 0
+	While $ListNext(overrides, pointer, override) {
+		Set memberType = $Piece(override,":")
+		Set memberName = $Piece(override,":",2)
+		If '..HasOverride(className, memberType, memberName, prohibitedOrigin, .oneStatus) {
+			Set sc = $$$ADDSC(sc,oneStatus)
+		}
+	}
+	Quit sc
+}
+
+/// Returns true if <var>memberName</var> in class <var>className</var> is defined and not abstract.
+/// Valid values for <var>memberType</var> are first letter of the member type, or the whole word:
+/// <ul>
+/// <li>p[arameter]</li>
+/// <li>m[ethod]</li>
+/// <li>x[data]</li>
+/// </ul>
+ClassMethod HasOverride(className As %Dictionary.Classname, memberType As %String, memberName As %Dictionary.Identifier, prohibitedOrigin As %Dictionary.Classname, Output status As %Status) As %Boolean [ Internal, Private ]
+{
+	Set status = $$$OK
+	Set memberType = $Case($ZConvert(memberType,"L"),
+		"method":$$$cCLASSmethod,
+		$$$cCLASSmethod:$$$cCLASSmethod,
+		"parameter":$$$cCLASSparameter,
+		$$$cCLASSparameter:$$$cCLASSparameter,
+		"xdata":$$$cCLASSxdata,
+		$$$cCLASSxdata:$$$cCLASSxdata)
+	Set isAbstract = $Case(memberType,
+		$$$cCLASSmethod:$$$comMemberKeyGet(className,memberType,memberName,$$$cMETHabstract),
+		$$$cCLASSparameter:$$$comMemberKeyGet(className,memberType,memberName,$$$cPARAMabstract),
+		$$$cCLASSxdata:0 /* XData blocks cannot be [Abstract] */)
+	Set origin = $$$comMemberKeyGet(className,memberType,memberName,$$$cXXXXorigin)
+	Set overridden = $$$comMemberDefined(className,memberType,memberName) && 'isAbstract && (origin '= prohibitedOrigin)
+	If 'overridden {
+		Set memberTypeDisplay = $Case(memberType,
+			$$$cCLASSmethod:"Method",
+			$$$cCLASSparameter:"Parameter",
+			$$$cCLASSxdata:"XData")
+		Set status = $$$ERROR($$$GeneralError,$$$FormatText("%1 %2 must be defined for class %3",memberTypeDisplay,memberName,className))
+	}
+	Quit overridden
+}
+
+}
+

--- a/cls/_pkg/isc/rest/handler.cls
+++ b/cls/_pkg/isc/rest/handler.cls
@@ -6,7 +6,7 @@ Include (%occErrors, %pkg.isc.rest.openAPI, %pkg.isc.rest.general)
 Class %pkg.isc.rest.handler Extends %CSP.REST [ System = 4 ]
 {
 
-/// Determines what mode queries using this REST handler will be run in.  Defaults to 0 (Logical Mode).\
+/// Determines what mode queries using this REST handler will be run in.  Defaults to 0 (Logical Mode).
 /// Overwrite in a subclass as 1 (ODBC Mode) or 2 (Display Mode).
 Parameter QuerySelectMode As INTEGER = 0;
 
@@ -89,8 +89,20 @@ XData UrlMap [ XMLNamespace = "http://www.intersystems.com/urlmap" ]
 </Routes>
 }
 
+/// Ensures all required parameters are overridden in non-abstract subclasses.
+ClassMethod "%%CheckClassValidity"() [ CodeMode = objectgenerator, GenerateAfter = SupportedVerbs, Internal, Private ]
+{
+	If (%class.Name = "%pkg.isc.rest.handler") {
+		Quit $$$OK
+	}
+	
+	// Require non-abstract CheckResourcePermitted and AuthenticationStrategy methods
+	Set overrides = $ListBuild("m:AuthenticationStrategy","m:CheckResourcePermitted")
+	Return ##class(%pkg.isc.rest.compileTimeCheck).RequireOverrides(overrides,"%pkg.isc.rest.handler")
+}
+
 /// Endpoint call to get the OpenAPI specification saved to disk, and write it to the page as JSON
-ClassMethod GetOpenAPISpecification() As %Status
+ClassMethod GetOpenAPISpecification() As %Status [ Final ]
 {
 	Kill params
 	Merge params = %request.Data
@@ -121,7 +133,7 @@ ClassMethod GetOpenAPISpecification() As %Status
 /// apiPath is the application path of the form "/your/application/"
 /// debug / internal are the same as the query parameters defined in BuildDocumentationEndpoint()
 /// response will be set to the generated OpenAPI specification
-ClassMethod ConsoleBuildOpenAPIDocumentation(apiPath, debug = 0, internal = 0, Output response As %pkg.isc.rest.openAPI.model.openAPI, endpointOverride As %String = "") As %Status
+ClassMethod ConsoleBuildOpenAPIDocumentation(apiPath, debug = 0, internal = 0, Output response As %pkg.isc.rest.openAPI.model.openAPI, endpointOverride As %String = "") As %Status [ Final ]
 {
 	Try {
 		Set buildLock = $System.AutoLock.Lock($Name($$$DocLocksBuildGbl),"E",1)
@@ -166,7 +178,7 @@ ClassMethod ConsoleBuildOpenAPIDocumentation(apiPath, debug = 0, internal = 0, O
 }
 
 /// Reports on the status of either the currently building documentation, or the last built documentation
-ClassMethod GetDocumentationBuildStatus() As %Status
+ClassMethod GetDocumentationBuildStatus() As %Status [ Final ]
 {
 	Kill params
 	Merge params = %request.Data
@@ -207,7 +219,7 @@ ClassMethod GetDocumentationBuildStatus() As %Status
 /// Query parameters are:
 ///   debug (defaults to 0): Whether or not to run documentation generators in debug mode
 ///   internal (defaults to 0): Whether or not to generate documentation appropriate for users with source code access
-ClassMethod BuildDocumentationEndpoint() As %Status
+ClassMethod BuildDocumentationEndpoint() As %Status [ Final ]
 {
 	Kill params
 	Merge params = %request.Data
@@ -254,7 +266,7 @@ ClassMethod BuildDocumentationEndpoint() As %Status
 /// Individual documentation generators should update $$$DocStageBuildDocTypeGbl( typeOfDocumentation) with their individual progress
 /// debug / internal are the same as the query parameters in BuildDocumentationEndpoint()
 /// application is equal to %request.Application
-ClassMethod BuildDocumentationInternal(debug, internal, application, userContextString, userContextID, userContextClass)
+ClassMethod BuildDocumentationInternal(debug, internal, application, userContextString, userContextID, userContextClass) [ Final, Internal ]
 {
 	// Init
 	Set buildLock = $System.AutoLock.Lock($Name($$$DocLocksBuildGbl),"E",1)
@@ -373,7 +385,7 @@ ClassMethod CheckSupports(pResourceClass As %Dictionary.CacheClassname, pOperati
 }
 
 /// Checks both strategy- and resource-level permissions
-ClassMethod CheckAllPermissions(pResourceClass As %Dictionary.CacheClassname, pID As %String, pOperation As %String, pUserContext As %String, ByRef pURLParams) As %Boolean
+ClassMethod CheckAllPermissions(pResourceClass As %Dictionary.CacheClassname, pID As %String, pOperation As %String, pUserContext As %String, ByRef pURLParams) As %Boolean [ Final ]
 {
 	Set strategy = ..AuthenticationStrategy()
 	Set authorized = 1
@@ -385,7 +397,7 @@ ClassMethod CheckAllPermissions(pResourceClass As %Dictionary.CacheClassname, pI
 }
 
 /// Subclasses must override this to define a custom authentication strategy class.
-ClassMethod AuthenticationStrategy() As %Dictionary.CacheClassname [ Abstract ]
+ClassMethod AuthenticationStrategy() As %Dictionary.Classname [ Abstract ]
 {
 }
 
@@ -424,7 +436,7 @@ ClassMethod OnPreDispatch(pUrl As %String, pMethod As %String, ByRef pContinue A
 	Quit sc
 }
 
-ClassMethod GetUserInfo() As %Status
+ClassMethod GetUserInfo() As %Status [ Final ]
 {
 	#dim %response As %CSP.Response
 	Set userContext = ..GetUserContext()
@@ -437,19 +449,19 @@ ClassMethod GetUserInfo() As %Status
 	Quit $$$OK
 }
 
-ClassMethod GetUserContext() As %pkg.isc.rest.model.resource
+ClassMethod GetUserContext() As %pkg.isc.rest.model.resource [ Final ]
 {
 	$$$ThrowOnError($ClassMethod(..AuthenticationStrategy(),"UserInfo",.userInfo))
 	Quit ..GetUserResource(.userInfo)
 }
 
-ClassMethod LogOut() As %Status
+ClassMethod LogOut() As %Status [ Final ]
 {
 	Quit $ClassMethod(..AuthenticationStrategy(),"Logout")
 }
 
 /// Creates a new instance of the resource (handling a POST request to the resource's endpoint)
-ClassMethod Create(resourceName As %String) As %Status
+ClassMethod Create(resourceName As %String) As %Status [ Final ]
 {
 	Set operation = $$$OperationCreate
 
@@ -492,12 +504,12 @@ ClassMethod Create(resourceName As %String) As %Status
 
 /// Wrapper around <method>Supports</method> for the <method>Create</method>
 /// operation. Use this wrapper so it can be invoked from Open API generation.
-ClassMethod CheckSupportsCreate(pResourceClass As %Dictionary.CacheClassname) [ CodeMode = expression, Internal ]
+ClassMethod CheckSupportsCreate(pResourceClass As %Dictionary.CacheClassname) [ CodeMode = expression, Final, Internal ]
 {
 ..CheckSupports(pResourceClass, $$$OperationCreate, $$$TypeOperationClass)
 }
 
-ClassMethod CollectionQuery(resourceName As %String) As %Status
+ClassMethod CollectionQuery(resourceName As %String) As %Status [ Final ]
 {
 	Set operation = $$$OperationQuery
 
@@ -545,12 +557,12 @@ ClassMethod CollectionQuery(resourceName As %String) As %Status
 
 /// Wrapper around <method>Supports</method> for the <method>CollectionQuery</method>
 /// operation. Use this wrapper so it can be invoked from Open API generation.
-ClassMethod CheckSupportsCollectionQuery(pResourceClass As %Dictionary.CacheClassname) [ CodeMode = expression, Internal ]
+ClassMethod CheckSupportsCollectionQuery(pResourceClass As %Dictionary.CacheClassname) [ CodeMode = expression, Final, Internal ]
 {
 ..CheckSupports(pResourceClass, $$$OperationQuery, $$$TypeOperationClass)
 }
 
-ClassMethod Retrieve(resourceName As %String, id As %String) As %Status
+ClassMethod Retrieve(resourceName As %String, id As %String) As %Status [ Final ]
 {
 	Set operation = $$$OperationRead
 
@@ -581,12 +593,12 @@ ClassMethod Retrieve(resourceName As %String, id As %String) As %Status
 
 /// Wrapper around <method>Supports</method> for the <method>Retrieve</method>
 /// operation. Use this wrapper so it can be invoked from Open API generation.
-ClassMethod CheckSupportsRetrieve(pResourceClass As %Dictionary.CacheClassname) [ CodeMode = expression, Internal ]
+ClassMethod CheckSupportsRetrieve(pResourceClass As %Dictionary.CacheClassname) [ CodeMode = expression, Final, Internal ]
 {
 ..CheckSupports(pResourceClass, $$$OperationRead, $$$TypeOperationInstance)
 }
 
-ClassMethod Construct(resourceName As %String) As %Status
+ClassMethod Construct(resourceName As %String) As %Status [ Final ]
 {
 	Set operation = $$$OperationActionNew
 
@@ -622,13 +634,13 @@ ClassMethod Construct(resourceName As %String) As %Status
 /// Wrapper around <method>Supports</method> for the <method>Construct</method>
 /// operation. Use this wrapper so it can be invoked from Open API generation.
 /// $$$OperationRead with no ID, or $$$OperationActionNew, is usable as validation for this special case.
-ClassMethod CheckSupportsConstruct(pResourceClass As %Dictionary.CacheClassname) [ CodeMode = expression, Internal ]
+ClassMethod CheckSupportsConstruct(pResourceClass As %Dictionary.CacheClassname) [ CodeMode = expression, Final, Internal ]
 {
 ..CheckSupports(pResourceClass, $$$OperationRead, $$$TypeOperationClass) ||
 ..CheckSupports(pResourceClass, $$$OperationActionNew, $$$TypeOperationClass)
 }
 
-ClassMethod Update(resourceName As %String, id As %String) As %Status
+ClassMethod Update(resourceName As %String, id As %String) As %Status [ Final ]
 {
 	Set operation = $$$OperationUpdate
 
@@ -666,12 +678,12 @@ ClassMethod Update(resourceName As %String, id As %String) As %Status
 
 /// Wrapper around <method>Supports</method> for the <method>Update</method>
 /// operation. Use this wrapper so it can be invoked from Open API generation.
-ClassMethod CheckSupportsUpdate(pResourceClass As %Dictionary.CacheClassname) [ CodeMode = expression, Internal ]
+ClassMethod CheckSupportsUpdate(pResourceClass As %Dictionary.CacheClassname) [ CodeMode = expression, Final, Internal ]
 {
 ..CheckSupports(pResourceClass, $$$OperationUpdate, $$$TypeOperationInstance)
 }
 
-ClassMethod Delete(resourceName As %String, id As %String) As %Status
+ClassMethod Delete(resourceName As %String, id As %String) As %Status [ Final ]
 {
 	Set operation = $$$OperationDelete
 
@@ -706,12 +718,12 @@ ClassMethod Delete(resourceName As %String, id As %String) As %Status
 
 /// Wrapper around <method>Supports</method> for the <method>Delete</method>
 /// operation. Use this wrapper so it can be invoked from Open API generation.
-ClassMethod CheckSupportsDelete(pResourceClass As %Dictionary.CacheClassname) [ CodeMode = expression, Internal ]
+ClassMethod CheckSupportsDelete(pResourceClass As %Dictionary.CacheClassname) [ CodeMode = expression, Final, Internal ]
 {
 ..CheckSupports(pResourceClass, $$$OperationDelete, $$$TypeOperationInstance)
 }
 
-ClassMethod DispatchClassAction(resourceName As %String, action As %String) As %Status
+ClassMethod DispatchClassAction(resourceName As %String, action As %String) As %Status [ Final ]
 {
 	Set operation = $$$OperationAction(action)
 
@@ -753,12 +765,12 @@ ClassMethod DispatchClassAction(resourceName As %String, action As %String) As %
 
 /// Wrapper around <method>Supports</method> for the <method>DispatchClassAction</method>
 /// operation. Use this wrapper so it can be invoked from Open API generation.
-ClassMethod CheckSupportsDispatchClassAction(pResourceClass As %Dictionary.CacheClassname, pAction As %String) [ CodeMode = expression, Internal ]
+ClassMethod CheckSupportsDispatchClassAction(pResourceClass As %Dictionary.CacheClassname, pAction As %String) [ CodeMode = expression, Final, Internal ]
 {
 ..CheckSupports(pResourceClass, $$$OperationAction(pAction), $$$TypeOperationClass)
 }
 
-ClassMethod DispatchInstanceAction(resourceName As %String, id As %String, action As %String) As %Status
+ClassMethod DispatchInstanceAction(resourceName As %String, id As %String, action As %String) As %Status [ Final ]
 {
 	Set operation = $$$OperationAction(action)
 
@@ -801,12 +813,12 @@ ClassMethod DispatchInstanceAction(resourceName As %String, id As %String, actio
 
 /// Wrapper around <method>Supports</method> for the <method>DispatchInstanceAction</method>
 /// operation. Use this wrapper so it can be invoked from Open API generation.
-ClassMethod CheckSupportsDispatchInstanceAction(pResourceClass As %Dictionary.CacheClassname, pAction As %String) [ CodeMode = expression, Internal ]
+ClassMethod CheckSupportsDispatchInstanceAction(pResourceClass As %Dictionary.CacheClassname, pAction As %String) [ CodeMode = expression, Final, Internal ]
 {
 ..CheckSupports(pResourceClass, $$$OperationAction(pAction), $$$TypeOperationInstance)
 }
 
-ClassMethod FindActionClass(pResource As %String, pAction As %String, pTarget As %String, Output pResourceClass As %Dictionary.CacheClassname) As %Dictionary.CacheClassname [ Private ]
+ClassMethod FindActionClass(pResource As %String, pAction As %String, pTarget As %String, Output pResourceClass As %Dictionary.CacheClassname) As %Dictionary.CacheClassname [ Final, Private ]
 {
 	#dim %response As %CSP.Response
 	#dim %request As %CSP.Request
@@ -874,19 +886,19 @@ ClassMethod FindActionClass(pResource As %String, pAction As %String, pTarget As
 	Return ""
 }
 
-ClassMethod FindAcceptedClass(pResource As %String) As %Dictionary.CacheClassname [ Private ]
+ClassMethod FindAcceptedClass(pResource As %String) As %Dictionary.CacheClassname [ Final, Private ]
 {
 	#dim %request As %CSP.Request
-	Quit ..FindClass(..GetMediaTypeListFromAcceptHeader(),pResource,..#HTTP406NOTACCEPTABLE)
+	Quit ..FindClass(..GetMediaTypeListFromAcceptHeader(),pResource,..#HTTP406NOTACCEPTABLE,1)
 }
 
-ClassMethod FindContentClass(pResource As %String) As %Dictionary.CacheClassname [ Private ]
+ClassMethod FindContentClass(pResource As %String) As %Dictionary.CacheClassname [ Final, Private ]
 {
 	#dim %request As %CSP.Request
 	Quit ..FindClass($ListBuild(..GetMediaTypeFromContentType()),pResource,..#HTTP415UNSUPPORTEDMEDIATYPE)
 }
 
-ClassMethod FindClass(pMediaTypeList As %Library.List, pResource As %String, pStatusWhenInvalid As %String) As %Dictionary.CacheClassname [ Private ]
+ClassMethod FindClass(pMediaTypeList As %Library.List, pResource As %String, pStatusWhenInvalid As %String, pLookForDefault As %Boolean = 0) As %Dictionary.CacheClassname [ Final, Private ]
 {
 	Set pointer = 0
 	Set resourceClass = ""
@@ -903,6 +915,20 @@ ClassMethod FindClass(pMediaTypeList As %Library.List, pResource As %String, pSt
 		}
 	}
 	
+	If pLookForDefault && (resourceClass = "") && ##class(%pkg.isc.rest.resourceMap).UniqueDefaultResourceExists($ClassName(),pResource,1,.id) {
+		Set defaultResourceClass = ##class(%pkg.isc.rest.resourceMap).ResourceClassGetStored(id)
+		Set mediaType = ##class(%pkg.isc.rest.resourceMap).MediaTypeGetStored(id)
+		Set orderedTypeList = ..OrderMediaTypeList(pMediaTypeList)
+		While $ListNext(orderedTypeList,pointer,type) {
+			// Convert accepted media type to RegEx
+			Set regEx = $Replace(type,"*",".*")
+			Set regEx = $Replace(regEx,"+","\+")
+			If $Match(mediaType,regEx) {
+				Set resourceClass = defaultResourceClass
+			}
+		}
+	}
+	
 	If (resourceClass = "") {
 		If ('foundJSON) {
 			Do ..ReportHttpStatusCode(pStatusWhenInvalid, $$$ERROR($$$GeneralError,"Only JSON is supported."))
@@ -914,14 +940,30 @@ ClassMethod FindClass(pMediaTypeList As %Library.List, pResource As %String, pSt
 	Return resourceClass
 }
 
-ClassMethod GetMediaTypeFromContentType() As %String [ Internal ]
+ClassMethod OrderMediaTypeList(pList As %List) As %List [ Final, Internal ]
+{
+	Set pointer = 0
+	While $ListNext(pList,pointer,item) {
+		Set order = $Length(item,"*")
+		Set array(order,$Increment(array(order))) = item
+	}
+	Set orderedList = ""
+	For order=1:1:3 {
+		For i=1:1:$Get(array(order)) {
+			Set orderedList = orderedList_$ListBuild(array(order,i))
+		}
+	}
+	Quit orderedList
+}
+
+ClassMethod GetMediaTypeFromContentType() As %String [ Final, Internal ]
 {
 	// Strip away charset/boundary: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type
 	// Strip away leading and trailing white space
 	Return $ZStrip($Piece(%request.ContentType, ";", 1), "<>W")
 }
 
-ClassMethod GetMediaTypeListFromAcceptHeader() As %Library.List [ Internal ]
+ClassMethod GetMediaTypeListFromAcceptHeader() As %Library.List [ Final, Internal ]
 {
 	// Order media types based on q-factor:
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept

--- a/cls/_pkg/isc/rest/handlerProjection.cls
+++ b/cls/_pkg/isc/rest/handlerProjection.cls
@@ -39,6 +39,36 @@ ClassMethod CreateProjection(classname As %String, ByRef parameters As %String, 
 	Quit sc
 }
 
+/// Called from trigger in resourceMap
+ClassMethod ValidateDefaultForHandlers(resourceClass As %Dictionary.Classname)
+{
+	Set validSC = $$$OK
+	Set handlerClasses = ##class(%Dictionary.ClassDefinition).SubclassOfFunc("%pkg.isc.rest.handler")
+	While handlerClasses.%Next(.sc) {
+		$$$ThrowOnError(sc)
+		Set handlerClass = handlerClasses.Name
+		If $$$comClassKeyGet(handlerClass,$$$cCLASSabstract) {
+			Continue
+		}
+		Try {
+			If $System.CLS.IsMthd(handlerClass, "CheckResourcePermitted") && $classmethod(handlerClass, "CheckResourcePermitted", resourceClass) {
+				Set resourceName = $Parameter(resourceClass,"RESOURCENAME")
+				If ##class(%pkg.isc.rest.resourceMap).UniqueDefaultResourceExists(handlerClass, resourceName, 1, .id) {
+					Set existingClass = ##class(%pkg.isc.rest.resourceMap).ResourceClassGetStored(id)
+					If existingClass '= resourceClass {
+						Set msg = $$$FormatText("%1 is already registered as the default resource for name %2 in dispatch class %3", existingClass, resourceName, handlerClass)
+						$$$ThrowStatus($$$ERROR($$$GeneralError,msg))
+					}
+				}
+			}
+		} Catch e {
+			set validSC = $$$ADDSC(validSC,e.AsStatus())
+		}
+	}
+	$$$ThrowOnError(sc)
+	$$$ThrowOnError(validSC)
+}
+
 /// Called from triggers in actionMap and resourceMap
 ClassMethod AddResourceWherePermitted(resourceClass As %Dictionary.Classname)
 {
@@ -80,6 +110,7 @@ ClassMethod AddPermittedClass(handlerClass As %Dictionary.Classname, resourceCla
 	Set target.ResourceClass = resourceClass
 	Set target.MediaType = source.MediaType
 	Set target.ResourceName = source.ResourceName
+	Set target.IsDefault = source.IsDefault
 	$$$ThrowOnError(target.%Save())
 	
 	// Insert/update actionMap (update should always be a no-op)

--- a/cls/_pkg/isc/rest/model/action/t/action.cls
+++ b/cls/_pkg/isc/rest/model/action/t/action.cls
@@ -135,7 +135,7 @@ Method %OnValidateObject() As %Status [ Private, ServerOnly = 1 ]
 		Set msg = $$$FormatText("Action %1: the following arguments are in the path but have no corresponding argument element: %2",..name,$ListToString(missingList))
 		Return $$$ERROR($$$GeneralError,msg)
 	}
-	Return $$$OK
+	Return sc
 }
 
 Method GetDependencies(pSourceClass As %String, ByRef pClassArray)
@@ -336,6 +336,8 @@ Method Generate(pSourceClass As %String, Output pCodeArray, Output pExpectedCont
 					$$$GENERATE("	Set args("_position_") = pInstance."_property)
 				}
 			}
+		} ElseIf (argument.source = "user-context") {
+			$$$GENERATE("Merge args("_position_") = pUserContext")
 		}
 	}
 	

--- a/cls/_pkg/isc/rest/model/action/t/argument.cls
+++ b/cls/_pkg/isc/rest/model/action/t/argument.cls
@@ -34,8 +34,11 @@ Property name As %String(XMLPROJECTION = "attribute");
 ///     <li>
 ///         id: The ID from the path for instance actions.
 ///     </li>
+///     <li>
+///         user-context: the user context object, as provided by the subclass of <class>%pkg.isc.rest.handler</class> in use
+///     </li>
 /// </ul>
-Property source As %String(VALUELIST = ",body,body-key,form-data,query,path,id", XMLPROJECTION = "attribute") [ InitialExpression = "query", Required ];
+Property source As %String(VALUELIST = ",body,body-key,form-data,query,path,id,user-context", XMLPROJECTION = "attribute") [ InitialExpression = "query", Required ];
 
 /// Target parameter in the method/query
 Property target As %String(XMLPROJECTION = "attribute") [ Required ];
@@ -49,7 +52,7 @@ Property required As %Boolean(XMLPROJECTION = "attribute") [ InitialExpression =
 /// <P>If this method returns an error then <METHOD>%ValidateObject</METHOD> will fail.
 Method %OnValidateObject() As %Status [ Private, ServerOnly = 1 ]
 {
-    Set sourcesWithNameNotRequired = $ListBuild("body", "body-key", "id")
+    Set sourcesWithNameNotRequired = $ListBuild("body", "body-key", "id", "user-context")
 	If '$ListFind(sourcesWithNameNotRequired, ..source) && (..name = "") {
         Set msg = "MUST have 'name' attribute set on argument unless source is one of "_$ListToString(sourcesWithNameNotRequired)
         Return $$$ERROR($$$GeneralError,msg)

--- a/cls/_pkg/isc/rest/model/adaptor.cls
+++ b/cls/_pkg/isc/rest/model/adaptor.cls
@@ -8,13 +8,13 @@ Class %pkg.isc.rest.model.adaptor Extends %pkg.isc.rest.model.dbMappedResource [
 Parameter SOURCECLASS As COSEXPRESSION [ Final ] = "$classname()";
 
 /// Uses the data from a persistent object to populate the properties of this model.
-ClassMethod GetModelFromObject(object As %Persistent) As %pkg.isc.rest.model.adaptor
+ClassMethod GetModelFromObject(object As %Persistent) As %pkg.isc.rest.model.adaptor [ Final ]
 {
 	Return object
 }
 
 /// Saves the model instance
-Method SaveModelInstance(pUserContext As %RegisteredObject)
+Method SaveModelInstance(pUserContext As %RegisteredObject) [ Final ]
 {
 	Do ..OnBeforeSaveModel(.pUserContext)
 	$$$ThrowOnError(..%Save())
@@ -22,7 +22,7 @@ Method SaveModelInstance(pUserContext As %RegisteredObject)
 }
 
 /// Deletes an instance of this model, based on the identifier <var>pID</var>
-ClassMethod DeleteModelInstance(pID As %String) As %Boolean
+ClassMethod DeleteModelInstance(pID As %String) As %Boolean [ Final ]
 {
 	If ..#IndexToUse = "ID" {
 		Set tSC = $classmethod(..#SOURCECLASS,"%DeleteId",pID)
@@ -38,25 +38,25 @@ ClassMethod DeleteModelInstance(pID As %String) As %Boolean
 
 /// JSONImport imports JSON or dynamic object input into this object.<br />
 /// The input argument is either JSON as a string or stream, or a subclass of %DynamicAbstractObject.
-Method JSONImport(input) As %Status
+Method JSONImport(input) As %Status [ Final ]
 {
 	Quit ..%JSONImport(.input, ..#JSONMAPPING)
 }
 
 /// Serialize a JSON enabled class as a JSON document and write it to the current device.
-Method JSONExport() As %Status
+Method JSONExport() As %Status [ Final ]
 {
 	Quit ..%JSONExport(..#JSONMAPPING)
 }
 
 /// Serialize a JSON enabled class as a JSON document and write it to a stream.
-Method JSONExportToStream(ByRef export As %Stream.Object) As %Status
+Method JSONExportToStream(ByRef export As %Stream.Object) As %Status [ Final ]
 {
 	Quit ..%JSONExportToStream(.export, ..#JSONMAPPING)
 }
 
 /// Serialize a JSON enabled class as a JSON document and return it as a string.
-Method JSONExportToString(ByRef %export As %String) As %Status
+Method JSONExportToString(ByRef %export As %String) As %Status [ Final ]
 {
 	Quit ..%JSONExportToString(.%export, ..#JSONMAPPING)
 }

--- a/cls/_pkg/isc/rest/model/dbMappedResource.cls
+++ b/cls/_pkg/isc/rest/model/dbMappedResource.cls
@@ -20,8 +20,16 @@ Parameter IndexToUse As STRING = "ID";
 /// If true, <method>GetModelFromResultRow</method> must be overridden and implemented.
 Parameter ConstructFromResultRow As BOOLEAN = 0;
 
+/// Ensures all required parameters are overridden in non-abstract subclasses.
+ClassMethod "%%CheckClassValidity"() [ CodeMode = objectgenerator, Internal, Private ]
+{
+	// Require defined RESOURCENAME and MEDIATYPE parameters
+	Set overrides = $ListBuild("p:RESOURCENAME","p:MEDIATYPE","p:SOURCECLASS")
+	Return ##class(%pkg.isc.rest.compileTimeCheck).RequireOverrides(overrides)
+}
+
 /// Returns an existing instance of this model, based on the identifier <var>index</var>, or a new instance if <var>index</var> is not supplied.
-ClassMethod GetModelInstance(index As %String) As %pkg.isc.rest.model.dbMappedResource
+ClassMethod GetModelInstance(index As %String) As %pkg.isc.rest.model.dbMappedResource [ Final ]
 {
 	// We might want to pass in an entire row (an object) instead of just an index to look up
 	// If that happens, use this method instead
@@ -80,7 +88,6 @@ ClassMethod DeleteModelInstance(pID As %String) As %Boolean [ Abstract ]
 /// building and running a query, and then printing out the result set in a json format.
 ClassMethod GetCollection(ByRef URLParams, selectMode As %Integer = 0)
 {
-	
 	set resultSet = ..ConstructAndRunQuery(.URLParams, selectMode)
     write "["
 
@@ -99,7 +106,7 @@ ClassMethod GetCollection(ByRef URLParams, selectMode As %Integer = 0)
     Write "]"
 }
 
-ClassMethod ConstructAndRunQuery(ByRef URLParams, selectMode As %Integer = 0) [ Internal, Private ]
+ClassMethod ConstructAndRunQuery(ByRef URLParams, selectMode As %Integer = 0) [ Final, Internal, Private ]
 {
 	Set query = ##class(%pkg.isc.rest.queryGenerator).GetQuery(..#SOURCECLASS, ..GetProxyColumnList(), ..#IndexToUse, .URLParams, .queryParams)
 	
@@ -142,7 +149,7 @@ Method JSONExportToString(ByRef %export As %String) As %Status
 }
 
 /// Subclasses should not need to override this method. Instead, implement <method>OnGetProxyColumnList</method>.
-ClassMethod GetProxyColumnList() As %DynamicObject [ CodeMode = objectgenerator, Internal ]
+ClassMethod GetProxyColumnList() As %DynamicObject [ CodeMode = objectgenerator, Final, Internal ]
 {
 	Set sc = $$$OK
 	Try {

--- a/cls/_pkg/isc/rest/model/proxy.cls
+++ b/cls/_pkg/isc/rest/model/proxy.cls
@@ -38,25 +38,25 @@ ClassMethod DeleteModelInstance(pID As %String) As %Boolean
 
 /// JSONImport imports JSON or dynamic object input into this object.<br />
 /// The input argument is either JSON as a string or stream, or a subclass of %DynamicAbstractObject.
-Method JSONImport(input) As %Status
+Method JSONImport(input) As %Status [ Final ]
 {
 	Quit ..%instance.%JSONImport(.input, ..#JSONMAPPING)
 }
 
 /// Serialize a JSON enabled class as a JSON document and write it to the current device.
-Method JSONExport() As %Status
+Method JSONExport() As %Status [ Final ]
 {
 	Quit ..%instance.%JSONExport(..#JSONMAPPING)
 }
 
 /// Serialize a JSON enabled class as a JSON document and write it to a stream.
-Method JSONExportToStream(ByRef export As %Stream.Object) As %Status
+Method JSONExportToStream(ByRef export As %Stream.Object) As %Status [ Final ]
 {
 	Quit ..%instance.%JSONExportToStream(.export, ..#JSONMAPPING)
 }
 
 /// Serialize a JSON enabled class as a JSON document and return it as a string.
-Method JSONExportToString(ByRef %export As %String) As %Status
+Method JSONExportToString(ByRef %export As %String) As %Status [ Final ]
 {
 	Quit ..%instance.%JSONExportToString(.%export, ..#JSONMAPPING)
 }

--- a/cls/_pkg/isc/rest/model/resource.cls
+++ b/cls/_pkg/isc/rest/model/resource.cls
@@ -6,16 +6,26 @@ Class %pkg.isc.rest.model.resource Extends (%RegisteredObject, %pkg.isc.rest.mod
 
 /// Name of the resource at the REST level
 /// Subclasses MUST override this
-/// TODO: Check this is non-abstract in non-abstract subclasses on compilation
 Parameter RESOURCENAME As STRING [ Abstract ];
 
 /// Content-Type implemented in this class
 /// Subclasses MAY override this
-/// TODO: Check this is non-abstract in non-abstract subclasses on compilation
 Parameter MEDIATYPE As STRING = "application/json";
+
+/// Set to 1 to treat this resource as the default for its name. This permit flexible matching on MEDIATYPE for GET requests; e.g.,
+/// given MEDIATYPE=application/json, a GET request for this resource name will match if Accept is set to */* or application/*
+Parameter DEFAULT As BOOLEAN;
 
 /// Maintains data in <class>%pkg.isc.rest.resourceMap</class> for this class.
 Projection ResourceMap As %pkg.isc.rest.model.resourceMapProjection;
+
+/// Ensures all required parameters are overridden in non-abstract subclasses.
+ClassMethod "%%CheckClassValidity"() [ CodeMode = objectgenerator, Internal, Private ]
+{
+	// Require defined RESOURCENAME and MEDIATYPE parameters
+	Set overrides = $ListBuild("p:RESOURCENAME","p:MEDIATYPE")
+	Return ##class(%pkg.isc.rest.compileTimeCheck).RequireOverrides(overrides)
+}
 
 /// Returns an instance of this model, based on the arguments supplied.
 ClassMethod GetModelInstance(args...) As %pkg.isc.rest.model.resource [ Abstract ]

--- a/cls/_pkg/isc/rest/model/resourceMapProjection.cls
+++ b/cls/_pkg/isc/rest/model/resourceMapProjection.cls
@@ -42,6 +42,7 @@ ClassMethod CreateProjection(classname As %String, ByRef parameters As %String, 
 		Set map.ResourceName = resourceName
 		Set map.MediaType = mediaType
 		Set map.ResourceClass = classname
+		Set map.IsDefault = $Select($Parameter(classname,"DEFAULT"):1,1:"")
 		$$$ThrowOnError(map.%Save())
 	} Catch e {
 		Set sc = e.AsStatus()

--- a/cls/_pkg/isc/rest/resourceMap.cls
+++ b/cls/_pkg/isc/rest/resourceMap.cls
@@ -8,24 +8,37 @@ Index ResourceClass On ResourceClass;
 
 Index UniqueByClassnames On (DispatchOrResourceClass, ResourceClass) [ Unique ];
 
+Index UniqueDefaultResource On (DispatchOrResourceClass, ResourceName, IsDefault) [ Data = MediaType, Unique ];
+
 /// Indicate a global for storage difinitions.
 Parameter DEFAULTGLOBAL = "^pkg.isc.rest.resourceMap";
 
 /// Set to null on resource class compilation, or to the dispatch class from the REST handler projection
-Property DispatchClass As %Dictionary.CacheClassname;
+Property DispatchClass As %Dictionary.Classname;
 
 /// Set to either the DispatchClass or the ResourceClass
-Property DispatchOrResourceClass As %Dictionary.CacheClassname [ Calculated, Required, SqlComputeCode = {Set {*} = $Case({DispatchClass},"":{ResourceClass},:{DispatchClass})}, SqlComputed ];
+Property DispatchOrResourceClass As %Dictionary.Classname [ Calculated, Required, SqlComputeCode = {Set {*} = $Case({DispatchClass},"":{ResourceClass},:{DispatchClass})}, SqlComputed ];
 
-Property ResourceName As %String(MAXLEN = 128);
+Property ResourceName As %String(MAXLEN = 128) [ Required ];
 
-Property MediaType As %String(MAXLEN = 128);
+Property MediaType As %String(MAXLEN = 128) [ Required ];
 
-Property ResourceClass As %Dictionary.CacheClassname;
+Property ResourceClass As %Dictionary.Classname [ Required ];
+
+/// Set to 1 if default, NULL if not. (Can only be 1 or null.)
+Property IsDefault As %Integer(MAXVAL = 1, MINVAL = 1);
 
 /// Recursive foreign key references the dispatch class-independent record associated with this one (possibly the current record).
 /// "Cascade" ensures that deletes/updates to the base record are propagated to dispatch class-specific records.
 ForeignKey BaseResourceMap(ResourceClass,ResourceName,MediaType) References %pkg.isc.rest.resourceMap(UniqueByContext) [ OnDelete = cascade, OnUpdate = cascade ];
+
+Trigger ValidateDefaultForHandlers [ Event = INSERT, Foreach = row/object ]
+{
+	New handlerClasses,handlerClass,sc
+	If {DispatchClass} = "" {
+		Do ##class(%pkg.isc.rest.handlerProjection).ValidateDefaultForHandlers({ResourceClass})
+	}
+}
 
 Trigger UpdatePermittedHandlers [ Event = INSERT, Foreach = row/object, Time = AFTER ]
 {
@@ -52,6 +65,9 @@ Storage Default
 </Value>
 <Value name="5">
 <Value>ResourceClass</Value>
+</Value>
+<Value name="6">
+<Value>IsDefault</Value>
 </Value>
 </Data>
 <DataLocation>^pkg.isc.rest.resourceMapD</DataLocation>

--- a/inc/_pkg/isc/rest/general.inc
+++ b/inc/_pkg/isc/rest/general.inc
@@ -19,7 +19,7 @@ ROUTINE %pkg.isc.rest.general [Type=INC]
 /// Operation to query a REST resource
 #define OperationQuery              "QUERY"
 /// Operation to perform a custom action with the provided name on a REST resource
-#define OperationAction(%action)    "ACTION:"_%action
+#define OperationAction(%action)    ("ACTION:"_%action)
 /// Operation to perform the special "new" action on a REST resource
 #define OperationActionNew          $$$OperationAction("new")
 

--- a/internal/testing/unit_tests/UnitTest/isc/rest/compileTimeValidation.cls
+++ b/internal/testing/unit_tests/UnitTest/isc/rest/compileTimeValidation.cls
@@ -1,0 +1,175 @@
+Class UnitTest.isc.rest.compileTimeValidation Extends UnitTest.isc.rest.openAPI.testCase
+{
+
+Method TestRequiredHandlerMethods()
+{
+	set sc = ..SetupClass("zUnitTest.isc.rest.handler", ["%pkg.isc.rest.handler"],, "UserContext",,, ,,, , 
+		["CheckResourcePermitted","AuthenticationStrategy"])
+	do $$$AssertStatusOK(sc, "REST Handler was set-up correctly")
+	set compileStatus = ..CompileClass("zUnitTest.isc.rest.handler")
+	do $$$AssertStatusOK(compileStatus, "REST Handler compiled without error.")
+	do $$$AssertStatusOK(..TeardownClass("zUnitTest.isc.rest.handler"))
+	
+	set sc = ..SetupClass("zUnitTest.isc.rest.handler", ["%pkg.isc.rest.handler"],, "UserContext",,, ,,, , 
+		["CheckResourcePermitted"])
+	do $$$AssertStatusOK(sc, "REST Handler was set-up correctly")
+	set compileStatus = ..CompileClass("zUnitTest.isc.rest.handler",.errorLog)
+	do $$$AssertStatusNotOK(compileStatus, "REST Handler compiled with error.")
+	do $$$AssertEquals(errorLog(1,"param",1),"Method AuthenticationStrategy must be defined for class zUnitTest.isc.rest.handler")
+	do $$$AssertStatusOK(..TeardownClass("zUnitTest.isc.rest.handler"))
+	
+	set sc = ..SetupClass("zUnitTest.isc.rest.handler", ["%pkg.isc.rest.handler"],, "UserContext",,, ,,, , 
+		["AuthenticationStrategy"])
+	do $$$AssertStatusOK(sc, "REST Handler was set-up correctly")
+	set compileStatus = ..CompileClass("zUnitTest.isc.rest.handler",.errorLog)
+	do $$$AssertStatusNotOK(compileStatus, "REST Handler compiled with error.")
+	do $$$AssertEquals(errorLog(1,"param",1),"Method CheckResourcePermitted must be defined for class zUnitTest.isc.rest.handler")
+	do $$$AssertStatusOK(..TeardownClass("zUnitTest.isc.rest.handler"))
+	
+	set sc = ..SetupClass("zUnitTest.isc.rest.handler", ["%pkg.isc.rest.handler"],, "UserContext")
+	do $$$AssertStatusOK(sc, "REST Handler was set-up correctly")
+	set compileStatus = ..CompileClass("zUnitTest.isc.rest.handler",.errorLog)
+	do $$$AssertStatusNotOK(compileStatus, "REST Handler compiled with error.")
+	do $$$AssertEquals(errorLog(1,"param",1),"Method AuthenticationStrategy must be defined for class zUnitTest.isc.rest.handler")
+	do $$$AssertEquals(errorLog(2,"param",1),"Method CheckResourcePermitted must be defined for class zUnitTest.isc.rest.handler")
+	do $$$AssertStatusOK(..TeardownClass("zUnitTest.isc.rest.handler"))
+}
+
+Method TestRequiredResourceParameters()
+{
+	do ..TeardownClass("zUnitTest.isc.rest.resource")
+	
+	set sc = ..SetupClass("zUnitTest.isc.rest.resource", ["%pkg.isc.rest.model.resource"],
+		{"RESOURCENAME":"unittest-resource"}, "TestProperty")
+	do $$$AssertStatusOK(sc, "Resource class was set up correctly")
+	set compileStatus = ..CompileClass("zUnitTest.isc.rest.resource")
+	do $$$AssertStatusOK(compileStatus, "Resource class compiled without error.")
+	do $$$AssertStatusOK(..TeardownClass("zUnitTest.isc.rest.resource"))
+	
+	set sc = ..SetupClass("zUnitTest.isc.rest.resource", ["%pkg.isc.rest.model.resource"],, "TestProperty")
+	do $$$AssertStatusOK(sc, "Resource class was set up correctly")
+	set compileStatus = ..CompileClass("zUnitTest.isc.rest.resource",.errorLog)
+	do $$$AssertStatusNotOK(compileStatus, "Resource class compiled with error.")
+	do $$$AssertEquals(errorLog(1,"param",1),"Parameter RESOURCENAME must be defined for class zUnitTest.isc.rest.resource")
+	do $$$AssertStatusOK(..TeardownClass("zUnitTest.isc.rest.resource"))
+}
+
+Method TestRequiredDBMappedResourceParameters()
+{
+	do ..TeardownClass("zUnitTest.isc.rest.resource")
+	
+	set sc = ..SetupClass("zUnitTest.isc.rest.resource", ["%Persistent","%pkg.isc.rest.model.dbMappedResource"],
+		{"SOURCECLASS":"zUnitTest.isc.rest.resource"}, "TestProperty")
+	do $$$AssertStatusOK(sc, "Resource class was set up correctly")
+	set compileStatus = ..CompileClass("zUnitTest.isc.rest.resource",.errorLog)
+	do $$$AssertStatusNotOK(compileStatus, "Resource class compiled with error.")
+	do $$$AssertEquals(errorLog(1,"param",1),"Parameter RESOURCENAME must be defined for class zUnitTest.isc.rest.resource")
+	do $$$AssertStatusOK(..TeardownClass("zUnitTest.isc.rest.resource"))
+	
+	set sc = ..SetupClass("zUnitTest.isc.rest.resource", ["%Persistent","%pkg.isc.rest.model.dbMappedResource"],
+		{"RESOURCENAME":"unittest-resource"}, "TestProperty")
+	do $$$AssertStatusOK(sc, "Resource class was set up correctly")
+	set compileStatus = ..CompileClass("zUnitTest.isc.rest.resource",.errorLog)
+	do $$$AssertStatusNotOK(compileStatus, "Resource class compiled with error.")
+	do $$$AssertEquals(errorLog(1,"param",1),"Parameter SOURCECLASS must be defined for class zUnitTest.isc.rest.resource")
+	do $$$AssertStatusOK(..TeardownClass("zUnitTest.isc.rest.resource"))
+	
+	set sc = ..SetupClass("zUnitTest.isc.rest.resource", ["%pkg.isc.rest.model.dbMappedResource"],, "TestProperty")
+	do $$$AssertStatusOK(sc, "Resource class was set up correctly")
+	set compileStatus = ..CompileClass("zUnitTest.isc.rest.resource",.errorLog)
+	do $$$AssertStatusNotOK(compileStatus, "Resource class compiled with error.")
+	do $$$AssertEquals(errorLog(1,"param",1),"Parameter RESOURCENAME must be defined for class zUnitTest.isc.rest.resource")
+	do $$$AssertEquals(errorLog(2,"param",1),"Parameter SOURCECLASS must be defined for class zUnitTest.isc.rest.resource")
+	do $$$AssertStatusOK(..TeardownClass("zUnitTest.isc.rest.resource"))
+}
+
+Method TestRequiredProxyParameters()
+{
+	do ..TeardownClass("zUnitTest.isc.rest.resource")
+	
+	set sc = ..SetupClass("zUnitTest.isc.rest.resource", ["%Persistent","%pkg.isc.rest.model.proxy"],
+		{"SOURCECLASS":"zUnitTest.isc.rest.resource"}, "TestProperty")
+	do $$$AssertStatusOK(sc, "Resource class was set up correctly")
+	set compileStatus = ..CompileClass("zUnitTest.isc.rest.resource",.errorLog)
+	do $$$AssertStatusNotOK(compileStatus, "Resource class compiled with error.")
+	do $$$AssertEquals(errorLog(1,"param",1),"Parameter RESOURCENAME must be defined for class zUnitTest.isc.rest.resource")
+	do $$$AssertStatusOK(..TeardownClass("zUnitTest.isc.rest.resource"))
+	
+	set sc = ..SetupClass("zUnitTest.isc.rest.resource", ["%Persistent","%pkg.isc.rest.model.proxy"],
+		{"RESOURCENAME":"unittest-resource"}, "TestProperty")
+	do $$$AssertStatusOK(sc, "Resource class was set up correctly")
+	set compileStatus = ..CompileClass("zUnitTest.isc.rest.resource",.errorLog)
+	do $$$AssertStatusNotOK(compileStatus, "Resource class compiled with error.")
+	do $$$AssertEquals(errorLog(1,"param",1),"Parameter SOURCECLASS must be defined for class zUnitTest.isc.rest.resource")
+	do $$$AssertStatusOK(..TeardownClass("zUnitTest.isc.rest.resource"))
+	
+	set sc = ..SetupClass("zUnitTest.isc.rest.resource", ["%pkg.isc.rest.model.proxy"],, "TestProperty")
+	do $$$AssertStatusOK(sc, "Resource class was set up correctly")
+	set compileStatus = ..CompileClass("zUnitTest.isc.rest.resource",.errorLog)
+	do $$$AssertStatusNotOK(compileStatus, "Resource class compiled with error.")
+	do $$$AssertEquals(errorLog(1,"param",1),"Parameter RESOURCENAME must be defined for class zUnitTest.isc.rest.resource")
+	do $$$AssertEquals(errorLog(2,"param",1),"Parameter SOURCECLASS must be defined for class zUnitTest.isc.rest.resource")
+	do $$$AssertStatusOK(..TeardownClass("zUnitTest.isc.rest.resource"))
+}
+
+Method TestRequiredAdaptorParameters()
+{
+	do ..TeardownClass("zUnitTest.isc.rest.resource")
+	
+	set sc = ..SetupClass("zUnitTest.isc.rest.resource", ["%Persistent","%pkg.isc.rest.model.adaptor"],
+		{"RESOURCENAME":"unittest-resource"}, "TestProperty")
+	do $$$AssertStatusOK(sc, "Resource class was set up correctly")
+	set compileStatus = ..CompileClass("zUnitTest.isc.rest.resource",.errorLog)
+	do $$$AssertStatusOK(compileStatus, "Resource class compiled without error.")
+	do $$$AssertStatusOK(..TeardownClass("zUnitTest.isc.rest.resource"))
+	
+	set sc = ..SetupClass("zUnitTest.isc.rest.resource", ["%pkg.isc.rest.model.adaptor"],, "TestProperty")
+	do $$$AssertStatusOK(sc, "Resource class was set up correctly")
+	set compileStatus = ..CompileClass("zUnitTest.isc.rest.resource",.errorLog)
+	do $$$AssertStatusNotOK(compileStatus, "Resource class compiled with error.")
+	do $$$AssertEquals(errorLog(1,"param",1),"Parameter RESOURCENAME must be defined for class zUnitTest.isc.rest.resource")
+	do $$$AssertStatusOK(..TeardownClass("zUnitTest.isc.rest.resource"))
+}
+
+Method TestMultiDefaultResources()
+{
+	do ..TeardownClass("zUnitTest.isc.rest.handler")
+	do ..TeardownClass("zUnitTest.isc.rest.resource1")
+	do ..TeardownClass("zUnitTest.isc.rest.resource2")
+	
+	set sc = ..SetupClass("zUnitTest.isc.rest.handler", ["%pkg.isc.rest.handler"],, "UserContext",,, ,,, , 
+		["CheckResourcePermitted","AuthenticationStrategy"])
+	do $$$AssertStatusOK(sc, "REST Handler was set-up correctly")
+	set compileStatus = ..CompileClass("zUnitTest.isc.rest.handler")
+	do $$$AssertStatusOK(compileStatus, "REST Handler compiled without error.")
+		
+	set sc = ..SetupClass("zUnitTest.isc.rest.resource1", ["%Persistent","%pkg.isc.rest.model.adaptor"],
+		{"RESOURCENAME":"unittest-resource","DEFAULT":1}, "TestProperty")
+	do $$$AssertStatusOK(sc, "Resource class was set up correctly")
+	set compileStatus = ..CompileClass("zUnitTest.isc.rest.resource1")
+	do $$$AssertStatusOK(compileStatus, "Resource class compiled without error.")
+		
+	set sc = ..SetupClass("zUnitTest.isc.rest.resource2", ["%Persistent","%pkg.isc.rest.model.adaptor"],
+		{"RESOURCENAME":"unittest-resource","DEFAULT":1}, "TestProperty")
+	do $$$AssertStatusOK(sc, "Resource class was set up correctly")
+	set compileStatus = ..CompileClass("zUnitTest.isc.rest.resource2",.errorLog)
+	do $$$AssertStatusNotOK(compileStatus, "Resource class compiled with error.")
+	do $$$AssertEquals(errorLog(1,"param",1),"zUnitTest.isc.rest.resource1 is already registered as the default resource for name unittest-resource in dispatch class zUnitTest.isc.rest.handler")
+	
+	do $$$AssertStatusOK(..TeardownClass("zUnitTest.isc.rest.handler"))
+	do $$$AssertStatusOK(..TeardownClass("zUnitTest.isc.rest.resource1"))
+	do $$$AssertStatusOK(..TeardownClass("zUnitTest.isc.rest.resource2"))
+}
+
+ClassMethod AuthenticationStrategy() As %Dictionary.CacheClassname
+{
+    quit ##class(%pkg.isc.rest.authentication.platformBased).%ClassName(1)
+}
+
+ClassMethod CheckResourcePermitted(resourceClass As %Dictionary.Classname) As %Boolean
+{
+	quit $Piece(resourceClass,".",1,3) = "zUnitTest.isc.rest"
+}
+
+}
+

--- a/internal/testing/unit_tests/UnitTest/isc/rest/handler.cls
+++ b/internal/testing/unit_tests/UnitTest/isc/rest/handler.cls
@@ -65,11 +65,36 @@ Method TestPerson01Query()
     }
 }
 
+Method TestPerson011QueryDefault()
+{
+    #dim request As %CSP.Request
+    Set request = ..mock("%CSP.Request", ..#CALLSREALMETHODS)
+    Set request.CgiEnvs("HTTP_ACCEPT") = "*/*"
+    Set request.Data("$orderBy", 1) = "name"
+    Do ..Request("GET", "person", .request, .response, .object)
+    Do $$$AssertEquals(response.Status, ##class(%CSP.REST).#HTTP200OK)
+    Do $$$AssertEquals(response.ContentType, ##class(UnitTest.isc.rest.sample.model.person).#MEDIATYPE)
+    If '$$$AssertEquals(object.%Size(), 200) {
+        Do $$$LogMessage("Response Size: "_object.%Size)
+    }
+}
+
 Method TestPerson02Get()
 {
     #dim request As %CSP.Request
     Set request = ..mock("%CSP.Request", ..#CALLSREALMETHODS)
     Set request.CgiEnvs("HTTP_ACCEPT") = ##class(%CSP.REST).#CONTENTTYPEJSON
+    Do ..Request("GET", "person/1", .request, .response, .object)
+    Do $$$AssertEquals(response.Status, ##class(%CSP.REST).#HTTP200OK)
+    Do $$$AssertEquals(response.ContentType, ##class(UnitTest.isc.rest.sample.model.person).#MEDIATYPE)
+    Set ..Person = object
+}
+
+Method TestPerson021GetDefault()
+{
+    #dim request As %CSP.Request
+    Set request = ..mock("%CSP.Request", ..#CALLSREALMETHODS)
+    Set request.CgiEnvs("HTTP_ACCEPT") = "application/*"
     Do ..Request("GET", "person/1", .request, .response, .object)
     Do $$$AssertEquals(response.Status, ##class(%CSP.REST).#HTTP200OK)
     Do $$$AssertEquals(response.ContentType, ##class(UnitTest.isc.rest.sample.model.person).#MEDIATYPE)
@@ -278,6 +303,17 @@ Method TestVendor6Construct()
     Do $$$AssertEquals(response.Status, ##class(%CSP.REST).#HTTP200OK)
     Do $$$AssertEquals(response.ContentType, ##class(UnitTest.isc.rest.sample.data.vendor).#MEDIATYPE)
     Do $$$AssertEquals(object.%Size(),1)
+}
+
+Method TestSettings1UserExpandedInfo()
+{
+    #dim request As %CSP.Request
+    Set request = ..mock("%CSP.Request", ..#CALLSREALMETHODS)
+    Set request.CgiEnvs("HTTP_ACCEPT") = ##class(%CSP.REST).#CONTENTTYPEJSON
+    Do ..Request("GET", "settings/$expanded-user-info", .request, .response, .object)
+    Do $$$AssertEquals(response.Status, ##class(%CSP.REST).#HTTP200OK)
+    Do $$$AssertEquals(response.ContentType, "application/json")
+    Do $$$AssertEquals(object.UsernameUpper,$ZConvert($Username,"U"))
 }
 
 Method TestBad01InvalidOrderBy()
@@ -520,6 +556,17 @@ Method TestSupportsResourceOverridden()
     Set request.CgiEnvs("HTTP_ACCEPT") = "application/json"
     Do ..Request("GET", "settings/$new", .request, .response, .object)
     Do $$$AssertEquals(response.Status, ##class(%CSP.REST).#HTTP404NOTFOUND)
+}
+
+Method TestOrderMediaTypeList()
+{
+	#define order(%arg) ##class(%pkg.isc.rest.handler).OrderMediaTypeList(%arg)
+	Do $$$LogMessage("Note: $$$order(%arg) is ##class(%pkg.isc.rest.handler).OrderMediaTypeList(%arg)")
+	Do $$$AssertEquals($$$order($lb("application/foo+bar.json","*/*")),$lb("application/foo+bar.json","*/*"))
+	Do $$$AssertEquals($$$order($lb("*/*","application/foo+bar.json")),$lb("application/foo+bar.json","*/*"))
+	Do $$$AssertEquals($$$order($lb("application/*","application/foo+bar.json")),$lb("application/foo+bar.json","application/*"))
+	Do $$$AssertEquals($$$order($lb("*/*","application/*")),$lb("application/*","*/*"))
+	Do $$$AssertEquals($$$order($lb("application/foo+bar.json","*/*","application/json")),$lb("application/foo+bar.json","application/json","*/*"))
 }
 
 }

--- a/internal/testing/unit_tests/UnitTest/isc/rest/openAPI.cls
+++ b/internal/testing/unit_tests/UnitTest/isc/rest/openAPI.cls
@@ -402,12 +402,12 @@ Method TestGenerationWithSharedResourceName()
 	Set openapi.IncludeForbiddenEndpoints = 0
 	
 	// Class setup
-	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class1", ["%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource","MEDIATYPE":"application/vnd.intersystems.apps.unittest.resource.1+json"}, "property1",,, ,,, , ["CheckPermission1:CheckPermission"]))
-	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class2", ["%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource","MEDIATYPE":"application/vnd.intersystems.apps.unittest.resource.2+json"}, "property2",,, ,,, , ["CheckPermission2:CheckPermission"]))
-	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class3", ["%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource"}, ,,, ,,, ["ActionMap1:ActionMap"], ["CheckPermission3:CheckPermission"]))
-	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class4", ["%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource","MEDIATYPE":"application/vnd.intersystems.apps.unittest.resource.4+json"}, "property3",,, ,,, , ["CheckPermission1:CheckPermission"]))
-	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class5", ["%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource","MEDIATYPE":"application/vnd.intersystems.apps.unittest.resource.5+json"}, "property3",,, ,,, , ["CheckPermission1:CheckPermission"]))
-	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class6", ["%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource","MEDIATYPE":"application/vnd.intersystems.apps.unittest.resource.6+json"}, ,,, ,,, ["ActionMap2:ActionMap"], ["CheckPermission1:CheckPermission"]))
+	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class1", ["%Persistent","%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource","SOURCECLASS":"zUnitTest.isc.rest.class1","MEDIATYPE":"application/vnd.intersystems.apps.unittest.resource.1+json"}, "property1",,, ,,, , ["CheckPermission1:CheckPermission"]))
+	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class2", ["%Persistent","%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource","SOURCECLASS":"zUnitTest.isc.rest.class2","MEDIATYPE":"application/vnd.intersystems.apps.unittest.resource.2+json"}, "property2",,, ,,, , ["CheckPermission2:CheckPermission"]))
+	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class3", ["%Persistent","%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource","SOURCECLASS":"zUnitTest.isc.rest.class3"}, ,,, ,,, ["ActionMap1:ActionMap"], ["CheckPermission3:CheckPermission"]))
+	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class4", ["%Persistent","%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource","SOURCECLASS":"zUnitTest.isc.rest.class4","MEDIATYPE":"application/vnd.intersystems.apps.unittest.resource.4+json"}, "property3",,, ,,, , ["CheckPermission1:CheckPermission"]))
+	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class5", ["%Persistent","%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource","SOURCECLASS":"zUnitTest.isc.rest.class5","MEDIATYPE":"application/vnd.intersystems.apps.unittest.resource.5+json"}, "property3",,, ,,, , ["CheckPermission1:CheckPermission"]))
+	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class6", ["%Persistent","%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource","SOURCECLASS":"zUnitTest.isc.rest.class6","MEDIATYPE":"application/vnd.intersystems.apps.unittest.resource.6+json"}, ,,, ,,, ["ActionMap2:ActionMap"], ["CheckPermission1:CheckPermission"]))
 	
 	// Class compilation
 	// As of now, only supported HTTP verbs in ActionMap:
@@ -550,7 +550,7 @@ Method TestSpecModificationMethods()
 	
 	// Resource class setup
 	// Use the poorly-typed setup from TestUndesiredArgumentsAndReturnTypesHandling() -- make sure the warnings are not present after being fixed using ModifyOpenAPISpecification
-	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class1", ["%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource"}, ,,, ,,, ["PoorlyTypedMethodsActionMap:ActionMap"], ["CheckPermissionAllowAll:CheckPermission","PoorlyTypedMethod1","PoorlyTypedMethod2","PoorlyTypedMethod3","ModifyOpenAPIInfoSpecModification:ModifyOpenAPIInfo"]))
+	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class1", ["%Persistent","%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource","SOURCECLASS":"zUnitTest.isc.rest.class1"}, ,,, ,,, ["PoorlyTypedMethodsActionMap:ActionMap"], ["CheckPermissionAllowAll:CheckPermission","PoorlyTypedMethod1","PoorlyTypedMethod2","PoorlyTypedMethod3","ModifyOpenAPIInfoSpecModification:ModifyOpenAPIInfo"]))
 	Do $$$AssertStatusOK(..CompileClass("zUnitTest.isc.rest.class1"))
 	
 	Do $$$AssertTrue(openapi.GetSpecificationI($$$NULLOREF, "/UnitTest/isc/rest/openAPI/api/"), "Specification generation completed without errors")
@@ -801,7 +801,7 @@ Method TestInvalidJSONMapping()
 	Set openapi.DEBUG = 0
 	
 	// Resource class setup
-	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class1", ["%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource", "JSONMAPPING":"NonexistentJSONMapping"}, ,,, ,,, , ["CheckPermissionAllowAll:CheckPermission"]))
+	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class1", ["%Persistent","%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource", "SOURCECLASS":"zUnitTest.isc.rest.class1", "JSONMAPPING":"NonexistentJSONMapping"}, ,,, ,,, , ["CheckPermissionAllowAll:CheckPermission"]))
 	
 	// Class compilation
 	Do $$$AssertStatusOK(..CompileClass("zUnitTest.isc.rest.class1"))
@@ -844,7 +844,7 @@ Method TestIncompatibleMediatypes()
 	Set openapi.DEBUG = 0
 	
 	// Resource class setup
-	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class1", ["%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource","MEDIATYPE":"image/png"}, ,,, ,,, , ["CheckPermissionAllowAll:CheckPermission"]))
+	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class1", ["%Persistent","%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource","SOURCECLASS":"zUnitTest.isc.rest.class1","MEDIATYPE":"image/png"}, ,,, ,,, , ["CheckPermissionAllowAll:CheckPermission"]))
 	
 	// Class compilation
 	Do $$$AssertStatusOK(..CompileClass("zUnitTest.isc.rest.class1"))
@@ -887,7 +887,7 @@ Method TestHideInternalInfoFlag()
 	Set openapi.HideInternalInfo = 1
 	
 	// Resource class setup
-	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class1", ["%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource"}, "TestProp", {"Type":"zUnitTest.isc.rest.class1"}, {"%JSONFIELDNAME":"testField"}, ,,, ["IntegerIdentityActionMap:ActionMap"], ["CheckPermissionAllowAll:CheckPermission","IntegerIdentity"]))
+	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class1", ["%Persistent","%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource","SOURCECLASS":"zUnitTest.isc.rest.class1"}, "TestProp", {"Type":"zUnitTest.isc.rest.class1"}, {"%JSONFIELDNAME":"testField"}, ,,, ["IntegerIdentityActionMap:ActionMap"], ["CheckPermissionAllowAll:CheckPermission","IntegerIdentity"]))
 	
 	// Class compilation
 	Do $$$AssertStatusOK(..CompileClass("zUnitTest.isc.rest.class1"))
@@ -919,13 +919,13 @@ Method TestIncludeForbiddenEndpointsFlag()
 	
 	// Resource class setup
 	// Behavior should differ when an invalid MEDIATYPE is defined on a resource, leading success responses to not be generated
-	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class1", ["%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource-1","MEDIATYPE":"image/png"}, ,,, ,,, , ["CheckPermissionAllowAll:CheckPermission"]))
+	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class1", ["%Persistent","%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource-1","SOURCECLASS":"zUnitTest.isc.rest.class1","MEDIATYPE":"image/png"}, ,,, ,,, , ["CheckPermissionAllowAll:CheckPermission"]))
 	// Behavior should differ when invalid methods are referenced, leading to success response removal
-	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class2", ["%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource-2"}, ,,, ,,, ["NonexistentMethodActionMap:ActionMap"], ["CheckPermissionAllowAll:CheckPermission"]))
+	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class2", ["%Persistent","%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource-2","SOURCECLASS":"zUnitTest.isc.rest.class2"}, ,,, ,,, ["NonexistentMethodActionMap:ActionMap"], ["CheckPermissionAllowAll:CheckPermission"]))
 	// Behavior should differ when endpoints have no reachable success response due to the CheckPermission() method
-	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class3", ["%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource-3"}, ,,, ,,, , ["CheckPermissionDenyAll:CheckPermission"]))
+	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class3", ["%Persistent","%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource-3","SOURCECLASS":"zUnitTest.isc.rest.class3"}, ,,, ,,, , ["CheckPermissionDenyAll:CheckPermission"]))
 	// Behavior should differ when endpoints have no reachable success response due to the ModifyOpenAPIInfo() method (ONLY when the endpoint has not been completely removed)
-	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class4", ["%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource"}, ,,, ,,, , ["CheckPermissionAllowAll:CheckPermission", "ModifyOpenAPIInfoRemoveQuery200Response:ModifyOpenAPIInfo"]))
+	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class4", ["%Persistent","%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource","SOURCECLASS":"zUnitTest.isc.rest.class4"}, ,,, ,,, , ["CheckPermissionAllowAll:CheckPermission", "ModifyOpenAPIInfoRemoveQuery200Response:ModifyOpenAPIInfo"]))
 	
 	// Class compilation
 	Do $$$AssertStatusOK(..CompileClass("zUnitTest.isc.rest.class1"))
@@ -975,7 +975,7 @@ Method TestNonexistantMethod()
 	Set openapi.DEBUG = 0
 	Set openapi.ForceAuthorizeAllEndpoints = 1
 	Set openapi.IncludeForbiddenEndpoints = 1
-	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class1", ["%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource"}, ,,, ,,, ["NonexistentMethodActionMap:ActionMap"], ["CheckPermissionAllowAll:CheckPermission"]))
+	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class1", ["%Persistent","%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource","SOURCECLASS":"zUnitTest.isc.rest.class1"}, ,,, ,,, ["NonexistentMethodActionMap:ActionMap"], ["CheckPermissionAllowAll:CheckPermission"]))
 	Do $$$AssertStatusOK(..CompileClass("zUnitTest.isc.rest.class1"))
 	Do $$$AssertTrue('openapi.GetSpecificationI($$$NULLOREF, "/UnitTest/isc/rest/openAPI/api/"), "Specification generation did NOT complete without errors")
 	Set spec = openapi.Specification
@@ -1010,8 +1010,8 @@ Method TestUndesiredArgumentAndReturnTypesHandling()
 	Set openapi.IncludeForbiddenEndpoints = 1
 	set st = ..SetupClass(
 		"zUnitTest.isc.rest.class1", 
-		["%pkg.isc.rest.model.dbMappedResource"], 
-		{"RESOURCENAME":"unittest-resource"}, ,,, ,,, 
+		["%Persistent","%pkg.isc.rest.model.dbMappedResource"], 
+		{"RESOURCENAME":"unittest-resource","SOURCECLASS":"zUnitTest.isc.rest.class1"}, ,,, ,,, 
 		["PoorlyTypedMethodsActionMap:ActionMap"], 
 		["CheckPermissionAllowAll:CheckPermission","PoorlyTypedMethod1","PoorlyTypedMethod2","PoorlyTypedMethod3"]
 	)
@@ -1091,8 +1091,8 @@ Method TestGetAllParametersFromSpec()
 	Set openapi.IncludeForbiddenEndpoints = 1
 	set st = ..SetupClass(
 		"zUnitTest.isc.rest.class1", 
-		["%pkg.isc.rest.model.dbMappedResource"], 
-		{"RESOURCENAME":"unittest-resource"}, ,,, ,,, 
+		["%Persistent","%pkg.isc.rest.model.dbMappedResource"], 
+		{"RESOURCENAME":"unittest-resource","SOURCECLASS":"zUnitTest.isc.rest.class1"}, ,,, ,,, 
 		["PoorlyTypedMethodsActionMap:ActionMap"], 
 		["CheckPermissionAllowAll:CheckPermission","PoorlyTypedMethod1","PoorlyTypedMethod2","PoorlyTypedMethod3"]
 	)
@@ -1122,8 +1122,8 @@ Method TestGetAllSchemaRefsFromSpec()
 	Set openapi.IncludeForbiddenEndpoints = 1
 	set st = ..SetupClass(
 		"zUnitTest.isc.rest.class1", 
-		["%pkg.isc.rest.model.dbMappedResource"], 
-		{"RESOURCENAME":"unittest-resource"}, ,,, ,,, 
+		["%Persistent","%pkg.isc.rest.model.dbMappedResource"], 
+		{"RESOURCENAME":"unittest-resource","SOURCECLASS":"zUnitTest.isc.rest.class1"}, ,,, ,,, 
 		["PoorlyTypedMethodsActionMap:ActionMap"], 
 		["CheckPermissionAllowAll:CheckPermission","PoorlyTypedMethod1","PoorlyTypedMethod2","PoorlyTypedMethod3"]
 	)
@@ -1149,7 +1149,7 @@ Method TestSchemaAutogenerationTagging()
 	Set openapi = ..SetupTestingEnvironment()
 	#Dim openapi As %pkg.isc.rest.openAPI
 	Set openapi.DEBUG = 0
-	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class1", ["%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource"}, "TestProp",,, ,,, ["ActionMap1:ActionMap"], ["CheckPermissionAllowAll:CheckPermission"]))
+	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class1", ["%Persistent","%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource","SOURCECLASS":"zUnitTest.isc.rest.class1"}, "TestProp",,, ,,, ["ActionMap1:ActionMap"], ["CheckPermissionAllowAll:CheckPermission"]))
 	Do $$$AssertStatusOK(..CompileClass("zUnitTest.isc.rest.class1"))
 	Do $$$AssertTrue(openapi.GetSpecificationI($$$NULLOREF, "/UnitTest/isc/rest/openAPI/api/"), "Specification generation completed without errors")
 	Set spec = openapi.Specification
@@ -1171,7 +1171,7 @@ Method TestNoSecurityDefinedWarning()
 	Set openapi = ..SetupTestingEnvironment()
 	#Dim openapi As %pkg.isc.rest.openAPI
 	Set openapi.DEBUG = 0
-	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class1", ["%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource"}))
+	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class1", ["%Persistent","%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource","SOURCECLASS":"zUnitTest.isc.rest.class1"}))
 	Do $$$AssertStatusOK(..CompileClass("zUnitTest.isc.rest.class1"))
 	Do $$$AssertTrue(openapi.GetSpecificationI($$$NULLOREF, "/UnitTest/isc/rest/openAPI/api/"), "Specification generation completed without errors")
 	Do $$$AssertTrue(openapi.Specification.Warnings.Count() > 0, "At least one warning was logged")
@@ -1196,8 +1196,8 @@ Method TestCollectionQueryOverride()
 	Set openapi = ..SetupTestingEnvironment()
 	#Dim openapi As %pkg.isc.rest.openAPI
 	Set openapi.DEBUG = 0
-	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class1", ["%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource"}, ,,, ,,, , ["CheckPermissionAllowAll:CheckPermission","GetCollectionCustom:GetCollection"]))
-	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class2", ["%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource-1"}, "TestClassProperty", {"Required":1},, ,,, , ["CheckPermissionAllowAll:CheckPermission","GetCollectionNonArray:GetCollection"]))
+	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class1", ["%Persistent","%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource","SOURCECLASS":"zUnitTest.isc.rest.class1"}, ,,, ,,, , ["CheckPermissionAllowAll:CheckPermission","GetCollectionCustom:GetCollection"]))
+	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class2", ["%Persistent","%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource-1","SOURCECLASS":"zUnitTest.isc.rest.class2"}, "TestClassProperty", {"Required":1},, ,,, , ["CheckPermissionAllowAll:CheckPermission","GetCollectionNonArray:GetCollection"]))
 	Do $$$AssertStatusOK(..CompileClass("zUnitTest.isc.rest.class1"))
 	Do $$$AssertStatusOK(..CompileClass("zUnitTest.isc.rest.class2"))
 	Do $$$AssertTrue(openapi.GetSpecificationI($$$NULLOREF, "/UnitTest/isc/rest/openAPI/api/"), "Specification generation completed without errors")
@@ -1285,7 +1285,7 @@ Method TestMultiHandlers()
 	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.handler2", ["%pkg.isc.rest.handler"],, ,,, ,,, , ["AuthenticationStrategy","CheckResourcePermitted"]))
 	Do $$$AssertStatusOK(..CompileClass("zUnitTest.isc.rest.handler2"))
 	
-	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class1", ["%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource"}, "TestProp",,, ,,, ["ActionMap1:ActionMap"], ["CheckPermissionAllowAll:CheckPermission"]))
+	Do $$$AssertStatusOK(..SetupClass("zUnitTest.isc.rest.class1", ["%Persistent","%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource","SOURCECLASS":"zUnitTest.isc.rest.class1"}, "TestProp",,, ,,, ["ActionMap1:ActionMap"], ["CheckPermissionAllowAll:CheckPermission"]))
 	Do $$$AssertStatusOK(..CompileClass("zUnitTest.isc.rest.class1"))
 	
 	New %restHandlerOverride

--- a/internal/testing/unit_tests/UnitTest/isc/rest/openAPI/nonTransientResource.cls
+++ b/internal/testing/unit_tests/UnitTest/isc/rest/openAPI/nonTransientResource.cls
@@ -1,4 +1,4 @@
-Class UnitTest.isc.rest.openAPI.nonTransientResource Extends (%Persistent, %pkg.isc.rest.model.dbMappedResource)
+Class UnitTest.isc.rest.openAPI.nonTransientResource Extends (%Persistent, %pkg.isc.rest.model.adaptor)
 {
 
 Parameter RESOURCENAME = "unittest-isc-rest-openapi-nontransient-resource";

--- a/internal/testing/unit_tests/UnitTest/isc/rest/openAPI/schema.cls
+++ b/internal/testing/unit_tests/UnitTest/isc/rest/openAPI/schema.cls
@@ -40,7 +40,7 @@ Method TestGetSchema()
 	Do $$$AssertEquals(schema.Items.SourceClasses.Count(), 0, "Schema Items has no source classes set")
 	
 	Do $$$LogMessage("*** Check input: UnitTest.isc.rest.openAPI.schema.transientClass1 collection")
-	Do $$$AssertStatusOK(..SetupClass("UnitTest.isc.rest.openAPI.schema.transientClass1", ["%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittes-resource-openapi-schema"}), "Class setup was successful")
+	Do $$$AssertStatusOK(..SetupClass("UnitTest.isc.rest.openAPI.schema.transientClass1", ["%Persistent","%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittes-resource-openapi-schema","SOURCECLASS":"UnitTest.isc.rest.openAPI.schema.transientClass1"}), "Class setup was successful")
 	Do $$$AssertStatusOK(..CompileClass("UnitTest.isc.rest.openAPI.schema.transientClass1"), "Class compile was successful")
 	Set openapi = ##class(%pkg.isc.rest.openAPI).%New()
 	Do neededClasses.Clear()

--- a/internal/testing/unit_tests/UnitTest/isc/rest/openAPI/testCase.cls
+++ b/internal/testing/unit_tests/UnitTest/isc/rest/openAPI/testCase.cls
@@ -163,7 +163,12 @@ Method TeardownClass(className) As %Boolean
 			Set classActionsName = className_".Actions"
 			&sql(DELETE from %pkg_isc_rest.resourceMap WHERE ResourceClass = :className)
 			&sql(DELETE from %pkg_isc_rest.actionMap WHERE ResourceClass = :className OR ImplementationClass = :classActionsName)
-			Return $system.OBJ.Delete(className, "-d/deleteextent")
+			Set sc = $system.OBJ.Delete(className, "-d/deleteextent")
+			If $$$ISERR(sc) {
+				Return $system.OBJ.Delete(className, "-d")
+			} Else {
+				Return sc
+			}
 		}
 	} Catch ex {
 		Write !, ex.DisplayString()
@@ -172,9 +177,10 @@ Method TeardownClass(className) As %Boolean
 	Return 0
 }
 
-Method CompileClass(className) As %Status
+Method CompileClass(className, Output errorLog) As %Status
 {
-	Return $System.OBJ.Compile(className,"bckry-d")
+	Kill errorLog
+	Return $System.OBJ.Compile(className,"bckry-d",.errorLog)
 }
 
 Method CompileClassList(ByRef classList) As %Status

--- a/internal/testing/unit_tests/UnitTest/isc/rest/openAPI/userContextPassing.cls
+++ b/internal/testing/unit_tests/UnitTest/isc/rest/openAPI/userContextPassing.cls
@@ -26,7 +26,7 @@ Method OnAfterOneTest() As %Status
 Method TestUserContextPersistentInDB()
 {
 	set sc = ..SetupClass("zUnitTest.isc.rest.handler", ["%pkg.isc.rest.handler"],, "UserContext",,, ,,, , 
-		["AuthenticationStrategy","CheckPermissionHandlerAllowAll:CheckPermission"])
+		["AuthenticationStrategy","CheckResourcePermitted","CheckPermissionHandlerAllowAll:CheckPermission"])
 	Do $$$AssertStatusOK(sc, "REST Handler was set-up correctly")
 	Do $$$AssertStatusOK(..CompileClass("zUnitTest.isc.rest.handler"), "REST Handler was compiled correctly")
 	
@@ -47,7 +47,7 @@ Method TestUserContextPersistentInDB()
 Method TestUserContextPersistentNotInDB()
 {
 	set sc = ..SetupClass("zUnitTest.isc.rest.handler", ["%pkg.isc.rest.handler"],, "UserContext",,, ,,, , 
-		["AuthenticationStrategy","CheckPermissionHandlerAllowAll:CheckPermission"])
+		["AuthenticationStrategy","CheckResourcePermitted","CheckPermissionHandlerAllowAll:CheckPermission"])
 	Do $$$AssertStatusOK(sc, "REST Handler was set-up correctly")
 	Do $$$AssertStatusOK(..CompileClass("zUnitTest.isc.rest.handler"), "REST Handler was compiled correctly")
 
@@ -66,12 +66,12 @@ Method TestUserContextPersistentNotInDB()
 Method TestUserContextNotPersistent()
 {
 	set sc = ..SetupClass("zUnitTest.isc.rest.handler", ["%pkg.isc.rest.handler"],, "UserContext",,, ,,, , 
-		["AuthenticationStrategy","CheckPermissionHandlerAllowAll:CheckPermission"])
+		["AuthenticationStrategy","CheckResourcePermitted","CheckPermissionHandlerAllowAll:CheckPermission"])
 	Do $$$AssertStatusOK(sc, "REST Handler was set-up correctly")
 	Do $$$AssertStatusOK(..CompileClass("zUnitTest.isc.rest.handler"), "REST Handler was compiled correctly")
 
 	// Setup
-	set sc = ..SetupClass("zUnitTest.isc.rest.transientClass1", ["%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource"}, "TestProperty")
+	set sc = ..SetupClass("zUnitTest.isc.rest.transientClass1", ["%pkg.isc.rest.model.dbMappedResource"], {"RESOURCENAME":"unittest-resource","SOURCECLASS":"zUnitTest.isc.rest.transientClass1"}, "TestProperty")
 	Do $$$AssertStatusOK(sc, "Transient serializable class was set-up correctly")
 	Do $$$AssertStatusOK(..CompileClass("zUnitTest.isc.rest.transientClass1"), "Transient serializable class was compiled correctly")
 	// Test
@@ -91,6 +91,11 @@ Method TestUserContextNotPersistent()
 ClassMethod AuthenticationStrategy() As %Dictionary.CacheClassname
 {
     Quit ##class(%pkg.isc.rest.authentication.platformBased).%ClassName(1)
+}
+
+ClassMethod CheckResourcePermitted(resourceClass As %Dictionary.Classname) As %Boolean
+{
+	Quit $Piece(resourceClass,".",1,3) = "zUnitTest.isc.rest"
 }
 
 ClassMethod CheckPermissionHandlerAllowAll(pEndpoint As %String, pUserContext As %RegisteredObject, ByRef URLParams) As %Boolean

--- a/internal/testing/unit_tests/UnitTest/isc/rest/sample/model/person.cls
+++ b/internal/testing/unit_tests/UnitTest/isc/rest/sample/model/person.cls
@@ -13,6 +13,9 @@ Parameter JSONMAPPING As STRING = "LimitedInfo";
 /// Subclasses MUST override this
 Parameter RESOURCENAME As STRING = "person";
 
+/// Set to 1 to treat this resource as the default for its name, to permit flexible matching on Accept header
+Parameter DEFAULT As BOOLEAN = 1;
+
 /// Permits READ and QUERY access only.
 ClassMethod CheckPermission(pID As %String, pOperation As %String, pUserContext As UnitTest.isc.rest.sample.userContext) As %Boolean
 {

--- a/internal/testing/unit_tests/UnitTest/isc/rest/sample/model/settings.cls
+++ b/internal/testing/unit_tests/UnitTest/isc/rest/sample/model/settings.cls
@@ -54,6 +54,21 @@ Method SaveModelInstance(pUserContext As %RegisteredObject)
     $$$ThrowOnError(sc)
 }
 
+/// Defines a mapping of actions available for this model class to the associated methods and arguments.
+XData ActionMap [ XMLNamespace = "http://www.intersystems.com/_pkg/isc/rest/action" ]
+{
+<actions>
+<action name="expanded-user-info" method="GET" target="class" call="GetUserExpandedInfo">
+<argument source="user-context" target="pUserContext" />
+</action>
+</actions>
+}
+
+ClassMethod GetUserExpandedInfo(pUserContext As UnitTest.isc.rest.sample.userContext) As %DynamicObject
+{
+	Quit {"UsernameUpper":($ZConvert(pUserContext.Username,"U"))}
+}
+
 /// Checks if the particular operation is supported for this resource. <br />
 /// Look at documentation of <method>SupportsDefault</method> for default behavior
 /// of this method. <br />
@@ -71,7 +86,7 @@ Method SaveModelInstance(pUserContext As %RegisteredObject)
 ClassMethod Supports(pOperation As %String, pType As %String(VALUELIST=",instance,class"), pRequest As %CSP.Request = {$$$NULLOREF}) As %Boolean
 {
     // Only support GET and POST with no path or query parameters
-    If (pType = "class") && ((pOperation = $$$OperationCreate) || (pOperation = $$$OperationQuery)) {
+    If (pType = "class") && ((pOperation = $$$OperationCreate) || (pOperation = $$$OperationQuery) || (pOperation = $$$OperationAction("expanded-user-info"))) {
         Return 1
     }
 	Return 0

--- a/preload/cls/pkg/isc/rest/lifecycle.cls
+++ b/preload/cls/pkg/isc/rest/lifecycle.cls
@@ -1,4 +1,4 @@
-Class %pkg.isc.rest.lifecycle Extends %ZPM.PackageManager.Developer.Lifecycle.Module
+Class pkg.isc.rest.lifecycle Extends %ZPM.PackageManager.Developer.Lifecycle.Module
 {
 ClassMethod RunOnLoad() [ CodeMode = objectgenerator ]
 {


### PR DESCRIPTION
APPS-13152: isc.rest should lock down methods as final + do compile time validation
APPS-13327: Add "user-context" source for arguments
APPS-12782: %pkg.isc.rest supports fallback mimetype/representation of a resource