### PR TITLE
Ignore any CSPDEBUG queryparam (fixes #8)

### DIFF
--- a/cls/_pkg/isc/rest/handler.cls
+++ b/cls/_pkg/isc/rest/handler.cls
@@ -734,6 +734,9 @@ ClassMethod DispatchClassAction(resourceName As %String, action As %String) As %
 		Kill params
 		Merge params = %request.Data
 		
+		// Discard debug trigger
+		Kill params("CSPDEBUG")
+		
 		Set actionClass = ..FindActionClass(resourceName, action, "class", .resourceClass)
 		If (actionClass = "") {
 			Quit

--- a/cls/_pkg/isc/rest/queryGenerator.cls
+++ b/cls/_pkg/isc/rest/queryGenerator.cls
@@ -44,6 +44,11 @@ ClassMethod BuildQuery(tableName As %String, columns As %DynamicObject, index As
 	Set propName = $Order(params(""))
 	While (propName '= "") {
 		Set param = params(propName, 1)
+		// ignore debug signal
+		If (propName = "CSPDEBUG") {
+			Set propName = $Order(params(propName))
+			Continue
+		}
 		// if the property is $orderBy, then we store the order by string
 		// for appending at the end of the where clause building
 		If (propName = "$orderBy") {


### PR DESCRIPTION
This PR fixes #8 so Serenji can debug REST endpoint code.